### PR TITLE
Disables Lithiums AI Mixin [1.19.3]

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -39,10 +39,10 @@
     "suggests": {
       "another-mod": "*"
     },
-	"custom": {
-		"lithium:options": {
-			"mixin.ai.task.memory_change_counting": false
-		}
-	}
+    "custom": {
+      "lithium:options": {
+	"mixin.ai.task.memory_change_counting": false
+      }
+    }
   }
   

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -38,6 +38,11 @@
     },
     "suggests": {
       "another-mod": "*"
-    }
+    },
+	"custom": {
+		"lithium:options": {
+			"mixin.ai.task.memory_change_counting": false
+		}
+	}
   }
   


### PR DESCRIPTION
Found a bug via CaffeineMC/lithium-fabric#447 that requires this in order to not crash.