### PR TITLE
Port to 1.19.4

### DIFF
--- a/Common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/EscapeSun.java
+++ b/Common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/EscapeSun.java
@@ -77,7 +77,7 @@ public class EscapeSun<E extends PathfinderMob> extends ExtendedBehaviour<E> {
 		if (walkTarget == null)
 			return false;
 
-		return walkTarget.getTarget().currentBlockPosition().equals(new BlockPos(this.hidePos)) && !entity.getNavigation().isDone();
+		return walkTarget.getTarget().currentBlockPosition().equals(BlockPos.containing(this.hidePos)) && !entity.getNavigation().isDone();
 	}
 
 	@Override

--- a/Common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/StayWithinDistanceOfAttackTarget.java
+++ b/Common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/StayWithinDistanceOfAttackTarget.java
@@ -132,7 +132,7 @@ public class StayWithinDistanceOfAttackTarget<E extends PathfinderMob> extends E
 				Vec3 runPos = DefaultRandomPos.getPosAway(entity, (int)maxDist, 5, target.position());
 
 				if (runPos != null)
-					navigation.moveTo(navigation.createPath(new BlockPos(runPos), 1), this.repositionSpeedMod);
+					navigation.moveTo(navigation.createPath(BlockPos.containing(runPos), 1), this.repositionSpeedMod);
 			}
 
 			return;

--- a/Common/src/main/java/net/tslat/smartbrainlib/object/FreePositionTracker.java
+++ b/Common/src/main/java/net/tslat/smartbrainlib/object/FreePositionTracker.java
@@ -19,7 +19,7 @@ public class FreePositionTracker implements PositionTracker {
 
 	@Override
 	public BlockPos currentBlockPosition() {
-		return new BlockPos(pos);
+		return BlockPos.containing(pos);
 	}
 
 	@Override

--- a/Common/src/main/java/net/tslat/smartbrainlib/object/SquareRadius.java
+++ b/Common/src/main/java/net/tslat/smartbrainlib/object/SquareRadius.java
@@ -17,7 +17,7 @@ public record SquareRadius(double xzRadius, double yRadius) {
 	}
 
 	public BlockPos toBlockPos() {
-		return new BlockPos(this.xzRadius, this.yRadius, this.xzRadius);
+		return BlockPos.containing(this.xzRadius, this.yRadius, this.xzRadius);
 	}
 
 	public Vec3 toVec3() {

--- a/Common/src/main/java/net/tslat/smartbrainlib/object/SquareRadius.java
+++ b/Common/src/main/java/net/tslat/smartbrainlib/object/SquareRadius.java
@@ -13,7 +13,7 @@ import net.minecraft.world.phys.Vec3;
  */
 public record SquareRadius(double xzRadius, double yRadius) {
 	public Vec3i toVec3i() {
-		return new Vec3i(this.xzRadius, this.yRadius, this.xzRadius);
+		return new Vec3i((int) this.xzRadius, (int) this.yRadius, (int) this.xzRadius);
 	}
 
 	public BlockPos toBlockPos() {

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
     mappings loom.layered() {
         officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${minecraft_version}:${mappings_version}@zip")
+        parchment("org.parchmentmc.data:parchment-1.19.3:${mappings_version}@zip")
     }
     modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
     "depends": {
       "fabricloader": ">=0.14",
       "fabric": "*",
-      "minecraft": "1.19.3",
+      "minecraft": "1.19.4",
       "java": ">=17"
     },
     "suggests": {

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -6,7 +6,7 @@ plugins {
 archivesBaseName = "${mod_name}-forge-${minecraft_version}"
 
 minecraft {
-    mappings channel: mappings_channel, version: "${mappings_version}-${minecraft_version}"
+    mappings channel: mappings_channel, version: "1.19.3-${mappings_version}-${minecraft_version}"
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[44,)"
+loaderVersion="[45,)"
 license="MPL-2.0"
 issueTrackerURL="https://github.com/Tslat/SmartBrainLib/issues"
 
@@ -17,12 +17,12 @@ A library mod for smarter Brains and easier usage of the Brain system.
 [[dependencies.smartbrainlib]]
 modId="forge"
 mandatory=true
-versionRange="[44,)"
+versionRange="[45,)"
 ordering="NONE"
 side="BOTH"
 [[dependencies.smartbrainlib]]
 modId="minecraft"
 mandatory=true
-versionRange="[1.19.3,)"
+versionRange="[1.19.4,)"
 ordering="NONE"
 side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ version=1.8.1
 group=net.tslat.smartbrainlib
 
 # Common
-minecraft_version=1.19.3
+minecraft_version=1.19.4
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 
 # Forge
-forge_version=44.1.16
+forge_version=45.0.8
 
 # Fabric
-fabric_version=0.73.2+1.19.3
-fabric_loader_version=0.14.13
+fabric_version=0.76.0+1.19.4
+fabric_loader_version=0.14.17
 
 # Quilt
 quilt_loader_version=0.18.1-beta.75


### PR DESCRIPTION
- Updates all `new BlockPos` calls to `BlockPos.containing`
- Still uses 1.19.3 parchment mappings as 1.19.4 not released yet. 

Tested both Forge and Fabric clients by summoning example mob and letting it do it's tasks. 