### PR TITLE
Add collection init version to group behaviours (1.21)

### DIFF
--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/AllApplicableBehaviours.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/AllApplicableBehaviours.java
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.ai.behavior.BehaviorControl;
 import net.tslat.smartbrainlib.object.SBLShufflingList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,6 +25,10 @@ public final class AllApplicableBehaviours<E extends LivingEntity> extends Group
 
 	@SafeVarargs
 	public AllApplicableBehaviours(ExtendedBehaviour<? super E>... behaviours) {
+		super(behaviours);
+	}
+
+	public AllApplicableBehaviours(Collection<Pair<ExtendedBehaviour<? super E>, Integer>> behaviours) {
 		super(behaviours);
 	}
 

--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/FirstApplicableBehaviour.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/FirstApplicableBehaviour.java
@@ -6,6 +6,9 @@ import net.minecraft.world.entity.LivingEntity;
 import net.tslat.smartbrainlib.object.SBLShufflingList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Group behaviour that attempts to run all sub-behaviours in order, until the first successful one.
  * @param <E> The entity
@@ -18,6 +21,10 @@ public final class FirstApplicableBehaviour<E extends LivingEntity> extends Grou
 
 	@SafeVarargs
 	public FirstApplicableBehaviour(ExtendedBehaviour<? super E>... behaviours) {
+		super(behaviours);
+	}
+
+	public FirstApplicableBehaviour(List<Pair<ExtendedBehaviour<? super E>, Integer>> behaviours) {
 		super(behaviours);
 	}
 

--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/GroupBehaviour.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/GroupBehaviour.java
@@ -8,6 +8,8 @@ import net.minecraft.world.entity.ai.memory.MemoryStatus;
 import net.tslat.smartbrainlib.object.SBLShufflingList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -37,6 +39,12 @@ public abstract class GroupBehaviour<E extends LivingEntity> extends ExtendedBeh
 		for (ExtendedBehaviour<? super E> behaviour : behaviours) {
 			this.behaviours.add(behaviour, 1);
 		}
+
+		noTimeout();
+	}
+
+	public GroupBehaviour(Collection<Pair<ExtendedBehaviour<? super E>, Integer>> behaviours) {
+		this.behaviours = new SBLShufflingList<>(behaviours);
 
 		noTimeout();
 	}

--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/OneRandomBehaviour.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/OneRandomBehaviour.java
@@ -6,6 +6,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.tslat.smartbrainlib.object.SBLShufflingList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+
 /**
  * Group behaviour that attempts to run sub-behaviours in a
  * @param <E> The entity
@@ -18,6 +20,10 @@ public final class OneRandomBehaviour<E extends LivingEntity> extends GroupBehav
 
 	@SafeVarargs
 	public OneRandomBehaviour(ExtendedBehaviour<? super E>... behaviours) {
+		super(behaviours);
+	}
+
+	public OneRandomBehaviour(Collection<Pair<ExtendedBehaviour<? super E>, Integer>> behaviours) {
 		super(behaviours);
 	}
 

--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/SequentialBehaviour.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/SequentialBehaviour.java
@@ -6,6 +6,8 @@ import net.minecraft.world.entity.LivingEntity;
 import net.tslat.smartbrainlib.object.SBLShufflingList;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -24,6 +26,10 @@ public final class SequentialBehaviour<E extends LivingEntity> extends GroupBeha
 
 	@SafeVarargs
 	public SequentialBehaviour(ExtendedBehaviour<? super E>... behaviours) {
+		super(behaviours);
+	}
+
+	public SequentialBehaviour(List<Pair<ExtendedBehaviour<? super E>, Integer>> behaviours) {
 		super(behaviours);
 	}
 

--- a/common/src/main/java/net/tslat/smartbrainlib/object/SBLShufflingList.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/object/SBLShufflingList.java
@@ -7,6 +7,7 @@ import net.minecraft.util.RandomSource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -27,6 +28,14 @@ public class SBLShufflingList<T> implements Iterable<T> {
 
 	public SBLShufflingList(Pair<T, Integer>... entries) {
 		this.entries = new ObjectArrayList<>(entries.length);
+
+		for (Pair<T, Integer> entry : entries) {
+			this.entries.add(new WeightedEntry<>(entry.getFirst(), entry.getSecond()));
+		}
+	}
+
+	public SBLShufflingList(Collection<Pair<T, Integer>> entries) {
+		this.entries = new ObjectArrayList<>(entries.size());
 
 		for (Pair<T, Integer> entry : entries) {
 			this.entries.add(new WeightedEntry<>(entry.getFirst(), entry.getSecond()));


### PR DESCRIPTION
Adds a contructor accepting collection values to `GroupBehaviour`.
This makes it easier to use if the grouped behaviours are not directly given to the contructor. I currently have some instances of this and the workaround is to dirty cast it to an array.

Sequential and FirstApplicable accepts it as a list only due to the ordering but others accept any collection