### PR TITLE
Debug name GroupBehaviour

### DIFF
--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/GroupBehaviour.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/GroupBehaviour.java
@@ -102,6 +102,11 @@ public abstract class GroupBehaviour<E extends LivingEntity> extends ExtendedBeh
 
 	@Override
 	public String toString() {
-		return "(" + getClass().getSimpleName() + "): " + (this.runningBehaviour != null ? this.runningBehaviour.getClass().getSimpleName() : "{}");
+		return "(" + getClass().getSimpleName() + "): " + (this.runningBehaviour != null ? this.runningBehaviour.toString() : "{}");
+	}
+
+	@Override
+	public String debugString() {
+		return getClass().getSimpleName() + " -> " + (this.runningBehaviour != null ? this.runningBehaviour.debugString() : "{}");
 	}
 }


### PR DESCRIPTION
Currently for `GroupBehaviour` with brain debugging enabled they will only display the root behaiour. This PR changes it.
Personally I think the `toString` formatting doesnt really fit the ui style which is why it differs.

Additionally i think `toString` should also delegate to the running behaviour underneath
If you dont know how the debug looks like this is it:

![2025-07-09_13 19 14](https://github.com/user-attachments/assets/93aa7544-e488-4af6-bb7e-177f031fe8b6)
