### PR TITLE
Update canFloat navigation state with FloatToSurfaceOfFluid behaviour

### DIFF
--- a/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/FloatToSurfaceOfFluid.java
+++ b/common/src/main/java/net/tslat/smartbrainlib/api/core/behaviour/custom/move/FloatToSurfaceOfFluid.java
@@ -21,6 +21,7 @@ import java.util.List;
  */
 public class FloatToSurfaceOfFluid<E extends Mob> extends ExtendedBehaviour<E> {
 	protected float riseChance = 0.8f;
+	private boolean canFloatPrevious;
 
 	/**
 	 * Set the chance per tick that the entity will 'jump' in water, rising up towards the surface.
@@ -49,8 +50,21 @@ public class FloatToSurfaceOfFluid<E extends Mob> extends ExtendedBehaviour<E> {
 	}
 
 	@Override
+	protected void start(E entity) {
+		super.start(entity);
+		this.canFloatPrevious = entity.getNavigation().canFloat();
+		entity.getNavigation().setCanFloat(true);
+	}
+
+	@Override
 	protected void tick(E entity) {
 		if (entity.getRandom().nextFloat() < this.riseChance)
 			entity.getJumpControl().jump();
+	}
+
+	@Override
+	protected void stop(E entity) {
+		super.stop(entity);
+		entity.getNavigation().setCanFloat(this.canFloatPrevious);
 	}
 }


### PR DESCRIPTION
Unlike its goal variant (`FloatGoal`) `FloatToSurfaceOfFluid` does not change the state of the entities navigator. This causes the entity to float up to the surface of fluids very rapidly unless the user sets the state themselves.

Since the goal updates it automatically i added this also the the behaviour. Albeit only when the entity is currently trying to float (the goal permanently modifies it)